### PR TITLE
Fix unclosed INP file handle

### DIFF
--- a/source/inochi2d/fmt/package.d
+++ b/source/inochi2d/fmt/package.d
@@ -198,8 +198,8 @@ void inWriteINPExtensions(Puppet p, string file) {
             f.skip(payloadLength);
         }
         extSectionEnd = f.tell();
-        f.close();
     }
+    f.close();
 
     ubyte[] fdata = cast(ubyte[])stdfile.read(file);
     ubyte[] app = fdata;


### PR DESCRIPTION
In certain cases inWriteINPExtensions did not close its read file handle, so the attempt to write to the file failed on Windows since the file handle was still holding the file lock.