### PR TITLE
MeshGroup: fixed wrong calculation for dynamic mode.

### DIFF
--- a/source/inochi2d/core/nodes/drawable.d
+++ b/source/inochi2d/core/nodes/drawable.d
@@ -86,8 +86,8 @@ private:
         if (preProcessed)
             return;
         preProcessed = true;
-        overrideTransformMatrix = null;
         if (preProcessFilter !is null) {
+            overrideTransformMatrix = null;
             mat4 matrix = this.transform.matrix;
             auto filterResult = preProcessFilter(vertices, deformation, &matrix);
             if (filterResult[0] !is null) {
@@ -103,8 +103,8 @@ private:
         if (postProcessed)
             return;
         postProcessed = true;
-        overrideTransformMatrix = null;
         if (postProcessFilter !is null) {
+            overrideTransformMatrix = null;
             mat4 matrix = this.transform.matrix;
             auto filterResult = postProcessFilter(vertices, deformation, &matrix);
             if (filterResult[0] !is null) {

--- a/source/inochi2d/core/nodes/meshgroup/package.d
+++ b/source/inochi2d/core/nodes/meshgroup/package.d
@@ -81,16 +81,10 @@ public:
                 index = bit - 1;
             }
             vec2 newPos = (index < 0)? cVertex: (triangles[index].transformMatrix * vec3(cVertex, 1)).xy;
-            if (dynamic)
-                origDeformation[i] = newPos - origVertices[i];
-            else
-                origDeformation[i] += newPos - cVertex;
+            origDeformation[i] += newPos - cVertex;
         }
 
-        if (dynamic)
-            return tuple(origDeformation, &forwardMatrix);
-        else
-            return tuple(origDeformation, cast(mat4*)null);
+        return tuple(origDeformation, cast(mat4*)null);
     }
 
     /**
@@ -104,10 +98,7 @@ public:
             }
             transformedVertices.length = vertices.length;
             foreach(i, vertex; vertices) {
-                if (dynamic)
-                    transformedVertices[i] = vec2(this.localTransform.matrix * vec4(vertex+this.deformation[i], 0, 1));
-                else
-                    transformedVertices[i] = vec2(vec4(vertex+this.deformation[i], 0, 1));
+                transformedVertices[i] = vertex+this.deformation[i];
             }
             foreach (index; 0..triangles.length) {
                 auto p1 = transformedVertices[data.indices[index * 3]];


### PR DESCRIPTION
In dynamic mode, children are rendered in wrong position.
This patch fixes the problem.