### PR TITLE
bug fix: changed way to specify one-time transformation for Drawable object.

### DIFF
--- a/source/inochi2d/core/nodes/drawable.d
+++ b/source/inochi2d/core/nodes/drawable.d
@@ -157,7 +157,7 @@ protected:
     MeshData data;
 
     @Ignore
-    Transform* oneTimeTransform = null;
+    mat4* oneTimeTransform = null;
 
     @Ignore
     class MatrixHolder {
@@ -456,7 +456,7 @@ public:
         vertices[] = data.vertices;
     }
 
-    void setOneTimeTransform(Transform* transform) {
+    void setOneTimeTransform(mat4* transform) {
         oneTimeTransform = transform;
 
         foreach (c; children) {
@@ -465,7 +465,7 @@ public:
         }
     }
 
-    Transform* getOneTimeTransform() {
+    mat4* getOneTimeTransform() {
         return oneTimeTransform;
     }
 

--- a/source/inochi2d/core/nodes/part/package.d
+++ b/source/inochi2d/core/nodes/part/package.d
@@ -168,7 +168,7 @@ private:
         if (overrideTransformMatrix !is null)
             matrix = overrideTransformMatrix.matrix;
         if (oneTimeTransform !is null)
-            matrix = (*oneTimeTransform).matrix * matrix;
+            matrix = (*oneTimeTransform) * matrix;
         static if (isMask) {
             partMaskShader.use();
             partMaskShader.setUniform(offset, data.origin);
@@ -711,7 +711,7 @@ public:
 
 
     override
-    void setOneTimeTransform(Transform* transform) {
+    void setOneTimeTransform(mat4* transform) {
         super.setOneTimeTransform(transform);
         foreach (m; masks) {
             m.maskSrc.oneTimeTransform = transform;


### PR DESCRIPTION
To show the children of MeshGroup in vertex edit mode, transformation matrix is overwritten in vertex edit mode.
Currently Transform object is passed as temporal transformation, but this way doesn't work correctly when some of the parents node applied T/R/S transformation.
This patch change the way to set one-time transformation overwrite. instead of transformation, mat4 object is directly passed. This solve the problem described here, together with modification  to the creator.