### PR TITLE
partial serialization

### DIFF
--- a/source/inochi2d/core/nodes/composite/package.d
+++ b/source/inochi2d/core/nodes/composite/package.d
@@ -210,8 +210,8 @@ protected:
     }
 
     override
-    void serializeSelf(ref InochiSerializer serializer) {
-        super.serializeSelf(serializer);
+    void serializeSelfImpl(ref InochiSerializer serializer, bool recursive=true) {
+        super.serializeSelfImpl(serializer, recursive);
 
         serializer.putKey("blend_mode");
         serializer.serializeValue(blendingMode);

--- a/source/inochi2d/core/nodes/drawable.d
+++ b/source/inochi2d/core/nodes/drawable.d
@@ -189,8 +189,8 @@ protected:
         Allows serializing self data (with pretty serializer)
     */
     override
-    void serializeSelf(ref InochiSerializer serializer) {
-        super.serializeSelf(serializer);
+    void serializeSelfImpl(ref InochiSerializer serializer, bool recursive=true) {
+        super.serializeSelfImpl(serializer, recursive);
         serializer.putKey("mesh");
         serializer.serializeValue(data);
     }

--- a/source/inochi2d/core/nodes/drivers/simplephysics.d
+++ b/source/inochi2d/core/nodes/drivers/simplephysics.d
@@ -216,8 +216,8 @@ protected:
         Allows serializing self data (with pretty serializer)
     */
     override
-    void serializeSelf(ref InochiSerializer serializer) {
-        super.serializeSelf(serializer);
+    void serializeSelfImpl(ref InochiSerializer serializer, bool recursive=true) {
+        super.serializeSelfImpl(serializer, recursive);
         serializer.putKey("param");
         serializer.serializeValue(paramRef);
         serializer.putKey("model_type");

--- a/source/inochi2d/core/nodes/meshgroup/package.d
+++ b/source/inochi2d/core/nodes/meshgroup/package.d
@@ -239,8 +239,8 @@ public:
     }
 
     override
-    void serializeSelf(ref InochiSerializer serializer) {
-        super.serializeSelf(serializer);
+    void serializeSelfImpl(ref InochiSerializer serializer, bool recursive = true) {
+        super.serializeSelfImpl(serializer, recursive);
 
         serializer.putKey("dynamic_deformation");
         serializer.serializeValue(dynamic);

--- a/source/inochi2d/core/nodes/package.d
+++ b/source/inochi2d/core/nodes/package.d
@@ -112,7 +112,7 @@ protected:
         if (parent !is null) parent.resetMask();
     }
 
-    void serializeSelf(ref InochiSerializer serializer) {
+    void serializeSelfImpl(ref InochiSerializer serializer, bool recursive=true) {
         
         serializer.putKey("uuid");
         serializer.putValue(uuid);
@@ -135,7 +135,7 @@ protected:
         serializer.putKey("lockToRoot");
         serializer.serializeValue(this.lockToRoot_);
         
-        if (children.length > 0) {
+        if (recursive && children.length > 0) {
             serializer.putKey("children");
             auto childArray = serializer.arrayBegin();
             foreach(child; children) {
@@ -150,6 +150,11 @@ protected:
             serializer.arrayEnd(childArray);
         }
     }
+
+    void serializeSelf(ref InochiSerializer serializer) {
+        serializeSelfImpl(serializer, true);
+    }
+
 
 package(inochi2d):
 
@@ -762,6 +767,10 @@ public:
 
 
         return null;
+    }
+
+    void serializePartial(ref InochiSerializer serializer, bool recursive = true) {
+        serializeSelfImpl(serializer, recursive);
     }
 
     /**

--- a/source/inochi2d/core/nodes/part/package.d
+++ b/source/inochi2d/core/nodes/part/package.d
@@ -267,8 +267,8 @@ protected:
         Allows serializing self data (with pretty serializer)
     */
     override
-    void serializeSelf(ref InochiSerializer serializer) {
-        super.serializeSelf(serializer);
+    void serializeSelfImpl(ref InochiSerializer serializer, bool recursive = true) {
+        super.serializeSelfImpl(serializer, recursive);
         version (InDoesRender) {
             if (inIsINPMode()) {
                 serializer.putKey("textures");
@@ -393,6 +393,24 @@ protected:
         // Update indices and vertices
         this.updateUVs();
         return null;
+    }
+
+    override
+    void serializePartial(ref InochiSerializer serializer, bool recursive=true) {
+        super.serializePartial(serializer, recursive);
+        serializer.putKey("textureUUIDs");
+        auto state = serializer.arrayBegin();
+            foreach(ref texture; textures) {
+                uint uuid;
+                if (texture !is null) {
+                    uuid = texture.getRuntimeUUID();                                    
+                } else {
+                    uuid = InInvalidUUID;
+                }
+                serializer.elemBegin;
+                serializer.putValue(cast(size_t)uuid);
+            }
+        serializer.arrayEnd(state);
     }
 
     //


### PR DESCRIPTION
Sometimes exporting object update via json object can be useful.
So far it always serialize all of children at once, so only if update for target object is required, always serialize all of children.
This patch introduces two functions:
1) Node.serializePartial:  serialize only target object without children.
2) Node.serializeSelfImpl:  called from serializeSelf and serializePartial, and serialize self based on specified recursive parameter.