### PR TITLE
suggestion for change of deserializer (1)

### DIFF
--- a/source/inochi2d/core/animation/animation.d
+++ b/source/inochi2d/core/animation/animation.d
@@ -51,8 +51,8 @@ public:
     int leadOut = -1;
 
 
-    void restructure(Puppet puppet) {
-        foreach(ref lane; lanes.dup) lane.restructure(puppet);
+    void restruct(Puppet puppet) {
+        foreach(ref lane; lanes.dup) lane.restruct(puppet);
     }
 
     /**
@@ -216,7 +216,7 @@ public:
         return 0;
     }
 
-    void restructure(Puppet puppet) {
+    void restruct(Puppet puppet) {
     }
     
     void finalize(Puppet puppet) {

--- a/source/inochi2d/core/animation/animation.d
+++ b/source/inochi2d/core/animation/animation.d
@@ -246,8 +246,7 @@ public:
         return 0;
     }
 
-    void reconstruct(Puppet puppet) {
-    }
+    void reconstruct(Puppet puppet) { }
     
     void finalize(Puppet puppet) {
         if (paramRef) paramRef.targetParam = puppet.findParameter(refuuid);

--- a/source/inochi2d/core/animation/animation.d
+++ b/source/inochi2d/core/animation/animation.d
@@ -50,6 +50,11 @@ public:
     */
     int leadOut = -1;
 
+
+    void restructure(Puppet puppet) {
+        foreach(ref lane; lanes.dup) lane.restructure(puppet);
+    }
+
     /**
         Finalizes the animation
     */
@@ -211,6 +216,9 @@ public:
         return 0;
     }
 
+    void restructure(Puppet puppet) {
+    }
+    
     void finalize(Puppet puppet) {
         if (paramRef) paramRef.targetParam = puppet.findParameter(refuuid);
     }

--- a/source/inochi2d/core/animation/animation.d
+++ b/source/inochi2d/core/animation/animation.d
@@ -51,8 +51,8 @@ public:
     int leadOut = -1;
 
 
-    void restruct(Puppet puppet) {
-        foreach(ref lane; lanes.dup) lane.restruct(puppet);
+    void reconstruct(Puppet puppet) {
+        foreach(ref lane; lanes.dup) lane.reconstruct(puppet);
     }
 
     /**
@@ -246,7 +246,7 @@ public:
         return 0;
     }
 
-    void restruct(Puppet puppet) {
+    void reconstruct(Puppet puppet) {
     }
     
     void finalize(Puppet puppet) {

--- a/source/inochi2d/core/automation/package.d
+++ b/source/inochi2d/core/automation/package.d
@@ -95,7 +95,7 @@ struct AutomationBinding {
         return null;
     }
 
-    void restruct(Puppet puppet) {
+    void reconstruct(Puppet puppet) {
     }
 
     void finalize(Puppet puppet) {
@@ -171,9 +171,9 @@ public:
     }
 
 
-    void restruct(Puppet puppet) {
+    void reconstruct(Puppet puppet) {
         foreach(ref binding; bindings.dup) {
-            binding.restruct(parent);
+            binding.reconstruct(parent);
         }
     }
 

--- a/source/inochi2d/core/automation/package.d
+++ b/source/inochi2d/core/automation/package.d
@@ -95,7 +95,7 @@ struct AutomationBinding {
         return null;
     }
 
-    void restructure(Puppet puppet) {
+    void restruct(Puppet puppet) {
     }
 
     void finalize(Puppet puppet) {
@@ -171,9 +171,9 @@ public:
     }
 
 
-    void restructure(Puppet puppet) {
+    void restruct(Puppet puppet) {
         foreach(ref binding; bindings.dup) {
-            binding.restructure(parent);
+            binding.restruct(parent);
         }
     }
 

--- a/source/inochi2d/core/automation/package.d
+++ b/source/inochi2d/core/automation/package.d
@@ -95,6 +95,9 @@ struct AutomationBinding {
         return null;
     }
 
+    void restructure(Puppet puppet) {
+    }
+
     void finalize(Puppet puppet) {
         foreach(ref parameter; puppet.parameters) {
             if (parameter.name == paramId) {
@@ -165,6 +168,13 @@ public:
     */
     void bind(AutomationBinding binding) {
         this.bindings ~= binding;
+    }
+
+
+    void restructure(Puppet puppet) {
+        foreach(ref binding; bindings.dup) {
+            binding.restructure(parent);
+        }
     }
 
     /**

--- a/source/inochi2d/core/automation/package.d
+++ b/source/inochi2d/core/automation/package.d
@@ -95,8 +95,7 @@ struct AutomationBinding {
         return null;
     }
 
-    void reconstruct(Puppet puppet) {
-    }
+    void reconstruct(Puppet puppet) { }
 
     void finalize(Puppet puppet) {
         foreach(ref parameter; puppet.parameters) {

--- a/source/inochi2d/core/nodes/drawable.d
+++ b/source/inochi2d/core/nodes/drawable.d
@@ -496,6 +496,13 @@ public:
         super.reparent(parent, pOffset);
     }
     
+    mat4 getDynamicMatrix() {
+        if (overrideTransformMatrix !is null) {
+            return overrideTransformMatrix.matrix;
+        } else {
+            return transform.matrix;
+        }
+    }
 }
 
 version (InDoesRender) {

--- a/source/inochi2d/core/nodes/package.d
+++ b/source/inochi2d/core/nodes/package.d
@@ -673,6 +673,12 @@ public:
     void drawOne() { }
 
 
+    void restructure() {
+        foreach(child; children.dup) {
+            child.restructure();
+        }
+    }
+
     /**
         Finalizes this node and any children
     */

--- a/source/inochi2d/core/nodes/package.d
+++ b/source/inochi2d/core/nodes/package.d
@@ -673,9 +673,9 @@ public:
     void drawOne() { }
 
 
-    void restructure() {
+    void restruct() {
         foreach(child; children.dup) {
-            child.restructure();
+            child.restruct();
         }
     }
 

--- a/source/inochi2d/core/nodes/package.d
+++ b/source/inochi2d/core/nodes/package.d
@@ -673,9 +673,9 @@ public:
     void drawOne() { }
 
 
-    void restruct() {
+    void reconstruct() {
         foreach(child; children.dup) {
-            child.restruct();
+            child.reconstruct();
         }
     }
 

--- a/source/inochi2d/core/param/binding.d
+++ b/source/inochi2d/core/param/binding.d
@@ -328,8 +328,7 @@ public:
     }
 
     override
-    void reconstruct(Puppet puppet) {
-    }
+    void reconstruct(Puppet puppet) { }
 
     /**
         Finalize loading of parameter

--- a/source/inochi2d/core/param/binding.d
+++ b/source/inochi2d/core/param/binding.d
@@ -39,7 +39,7 @@ abstract class ParameterBinding {
     /**
         Restructure object before finalization
     */
-    abstract void restruct(Puppet puppet);
+    abstract void reconstruct(Puppet puppet);
 
     /**
         Finalize loading of parameter
@@ -328,7 +328,7 @@ public:
     }
 
     override
-    void restruct(Puppet puppet) {
+    void reconstruct(Puppet puppet) {
     }
 
     /**

--- a/source/inochi2d/core/param/binding.d
+++ b/source/inochi2d/core/param/binding.d
@@ -39,7 +39,7 @@ abstract class ParameterBinding {
     /**
         Restructure object before finalization
     */
-    abstract void restructure(Puppet puppet);
+    abstract void restruct(Puppet puppet);
 
     /**
         Finalize loading of parameter
@@ -328,7 +328,7 @@ public:
     }
 
     override
-    void restructure(Puppet puppet) {
+    void restruct(Puppet puppet) {
     }
 
     /**

--- a/source/inochi2d/core/param/binding.d
+++ b/source/inochi2d/core/param/binding.d
@@ -37,6 +37,11 @@ struct BindTarget {
 abstract class ParameterBinding {
 
     /**
+        Restructure object before finalization
+    */
+    abstract void restructure(Puppet puppet);
+
+    /**
         Finalize loading of parameter
     */
     abstract void finalize(Puppet puppet);
@@ -322,12 +327,19 @@ public:
         return null;
     }
 
+    override
+    void restructure(Puppet puppet) {
+    }
+
     /**
         Finalize loading of parameter
     */
     override
     void finalize(Puppet puppet) {
+//        writefln("finalize binding %s", this.getName());
+
         this.target.node = puppet.find(nodeRef);
+//        writefln("node for %d = %x", nodeRef, &(target.node));
     }
 
     /**

--- a/source/inochi2d/core/param/package.d
+++ b/source/inochi2d/core/param/package.d
@@ -324,9 +324,9 @@ public:
         return null;
     }
 
-    void restruct(Puppet puppet) {
+    void reconstruct(Puppet puppet) {
         foreach(i, binding; bindings) {
-            binding.restruct(puppet);
+            binding.reconstruct(puppet);
         }
     }
 

--- a/source/inochi2d/core/param/package.d
+++ b/source/inochi2d/core/param/package.d
@@ -324,9 +324,9 @@ public:
         return null;
     }
 
-    void restructure(Puppet puppet) {
+    void restruct(Puppet puppet) {
         foreach(i, binding; bindings) {
-            binding.restructure(puppet);
+            binding.restruct(puppet);
         }
     }
 

--- a/source/inochi2d/core/param/package.d
+++ b/source/inochi2d/core/param/package.d
@@ -324,6 +324,12 @@ public:
         return null;
     }
 
+    void restructure(Puppet puppet) {
+        foreach(i, binding; bindings) {
+            binding.restructure(puppet);
+        }
+    }
+
     /**
         Finalize loading of parameter
     */

--- a/source/inochi2d/core/param/package.d
+++ b/source/inochi2d/core/param/package.d
@@ -112,6 +112,32 @@ private:
 
     Combinator iadd;
     Combinator imul;
+protected:
+    void serializeSelf(ref InochiSerializer serializer) {
+        serializer.putKey("uuid");
+        serializer.putValue(uuid);
+        serializer.putKey("name");
+        serializer.putValue(name);
+        serializer.putKey("is_vec2");
+        serializer.putValue(isVec2);
+        serializer.putKey("min");
+        min.serialize(serializer);
+        serializer.putKey("max");
+        max.serialize(serializer);
+        serializer.putKey("defaults");
+        defaults.serialize(serializer);
+        serializer.putKey("axis_points");
+        serializer.serializeValue(axisPoints);
+        serializer.putKey("merge_mode");
+        serializer.serializeValue(mergeMode);
+        serializer.putKey("bindings");
+        auto arrstate = serializer.arrayBegin();
+            foreach(binding; bindings) {
+                serializer.elemBegin();
+                binding.serializeSelf(serializer);
+            }
+        serializer.arrayEnd(arrstate);
+    }
 
 public:
     /**
@@ -257,29 +283,7 @@ public:
     */
     void serialize(ref InochiSerializer serializer) {
         auto state = serializer.objectBegin;
-            serializer.putKey("uuid");
-            serializer.putValue(uuid);
-            serializer.putKey("name");
-            serializer.putValue(name);
-            serializer.putKey("is_vec2");
-            serializer.putValue(isVec2);
-            serializer.putKey("min");
-            min.serialize(serializer);
-            serializer.putKey("max");
-            max.serialize(serializer);
-            serializer.putKey("defaults");
-            defaults.serialize(serializer);
-            serializer.putKey("axis_points");
-            serializer.serializeValue(axisPoints);
-            serializer.putKey("merge_mode");
-            serializer.serializeValue(mergeMode);
-            serializer.putKey("bindings");
-            auto arrstate = serializer.arrayBegin();
-                foreach(binding; bindings) {
-                    serializer.elemBegin();
-                    binding.serializeSelf(serializer);
-                }
-            serializer.arrayEnd(arrstate);
+        serializeSelf(serializer);
         serializer.objectEnd(state);
     }
 

--- a/source/inochi2d/core/puppet.d
+++ b/source/inochi2d/core/puppet.d
@@ -748,16 +748,16 @@ public:
     }
 
 
-    void restruct() {
-        this.root.restruct();
+    void reconstruct() {
+        this.root.reconstruct();
         foreach(parameter; parameters.dup) {
-            parameter.restruct(this);
+            parameter.reconstruct(this);
         }
         foreach(automation_; automation.dup) {
-            automation_.restruct(this);
+            automation_.reconstruct(this);
         }
         foreach(ref animation; animations.dup) {
-            animation.restruct(this);
+            animation.reconstruct(this);
         }
     }
 
@@ -784,8 +784,8 @@ public:
         Finalizer
     */
     void finalizeDeserialization(Fghj data) {
-        // restruct object path so that object is located at final position
-        restruct();
+        // reconstruct object path so that object is located at final position
+        reconstruct();
         finalize();
     }
 

--- a/source/inochi2d/core/puppet.d
+++ b/source/inochi2d/core/puppet.d
@@ -748,16 +748,16 @@ public:
     }
 
 
-    void restructure() {
-        this.root.restructure();
+    void restruct() {
+        this.root.restruct();
         foreach(parameter; parameters.dup) {
-            parameter.restructure(this);
+            parameter.restruct(this);
         }
         foreach(automation_; automation.dup) {
-            automation_.restructure(this);
+            automation_.restruct(this);
         }
         foreach(ref animation; animations.dup) {
-            animation.restructure(this);
+            animation.restruct(this);
         }
     }
 
@@ -784,8 +784,8 @@ public:
         Finalizer
     */
     void finalizeDeserialization(Fghj data) {
-        // restructure object path so that object is located at final position
-        restructure();
+        // restruct object path so that object is located at final position
+        restruct();
         finalize();
     }
 


### PR DESCRIPTION
This patch suggest new deserialization which uses two phase finalizer.
finalizer is decomposed into two step. restruct and finalize.
restruct change the position of the object in the tree. finalize maintains the link.
By introducing this steps, we can dynamically change the structure of the model after loading.

This helps reconstruction of the model structure, and saves into new format.