### PR TITLE
Bug fix: MeshGroup: fix condition to setupChild. MeshGroup child is excluded.

### DIFF
--- a/source/inochi2d/core/nodes/meshgroup/package.d
+++ b/source/inochi2d/core/nodes/meshgroup/package.d
@@ -260,15 +260,15 @@ public:
     void setupChild(Node child) {
  
         void setGroup(Drawable drawable) {
-            if (dynamic) {
-                drawable.preProcessFilter  = null;
-                drawable.postProcessFilter = &filterChildren;
-            } else {
-                drawable.preProcessFilter  = &filterChildren;
-                drawable.postProcessFilter = null;
-            }
             auto group = cast(MeshGroup)drawable;
             if (group is null) {
+                if (dynamic) {
+                    drawable.preProcessFilter  = null;
+                    drawable.postProcessFilter = &filterChildren;
+                } else {
+                    drawable.preProcessFilter  = &filterChildren;
+                    drawable.postProcessFilter = null;
+                }
                 foreach (child; drawable.children) {
                     auto childDrawable = cast(Drawable)child;
                     if (childDrawable !is null)


### PR DESCRIPTION
Currently sub-MeshGroup is excluded from parent MeshGroup deformation to keep performance in design.
However current implementation updates the vertex position of MeshGroup ( that is not reflected to deformation of descendant nodes.)
This result in showing mesh vertices in incorrect position for child MeshGroup which belongs to another MeshGroup.
This patch fixes that behaviour.