### PR TITLE
Meshgroup extension: Add translateChildren mode.

### DIFF
--- a/source/inochi2d/core/nodes/meshgroup/package.d
+++ b/source/inochi2d/core/nodes/meshgroup/package.d
@@ -280,19 +280,15 @@ public:
         void setGroup(Node node) {
             auto drawable = cast(Drawable)node;
             auto group    = cast(MeshGroup)node;
-            writefln("traverse: %s", node.name);
             if (translateChildren || (group is null && drawable !is null)) {
                 if (dynamic) {
-                    writefln("set post filter: %s-%s(%s)", name, node.name, node.typeId());
                     node.preProcessFilter  = null;
                     node.postProcessFilter = &filterChildren;
                 } else {
-                    writefln("set pre filter: %s-%s(%s)", name, node.name, node.typeId());
                     node.preProcessFilter  = &filterChildren;
                     node.postProcessFilter = null;
                 }
             } else {
-                writefln("clear filter: %s-%s(%s)", name, node.name, node.typeId());
                 node.preProcessFilter  = null;
                 node.postProcessFilter = null;
             }

--- a/source/inochi2d/core/nodes/meshgroup/package.d
+++ b/source/inochi2d/core/nodes/meshgroup/package.d
@@ -260,15 +260,15 @@ public:
     void setupChild(Node child) {
  
         void setGroup(Drawable drawable) {
-            if (dynamic) {
-                drawable.preProcessFilter  = null;
-                drawable.postProcessFilter = &filterChildren;
-            } else {
-                drawable.preProcessFilter  = &filterChildren;
-                drawable.postProcessFilter = null;
-            }
             auto group = cast(MeshGroup)drawable;
             if (group is null) {
+                if (dynamic) {
+                    drawable.preProcessFilter  = null;
+                    drawable.postProcessFilter = &filterChildren;
+                } else {
+                    drawable.preProcessFilter  = &filterChildren;
+                    drawable.postProcessFilter = null;
+                }
                 foreach (child; drawable.children) {
                     auto childDrawable = cast(Drawable)child;
                     if (childDrawable !is null)

--- a/source/inochi2d/core/nodes/meshgroup/package.d
+++ b/source/inochi2d/core/nodes/meshgroup/package.d
@@ -332,7 +332,7 @@ public:
                     if (filterResult[0] !is null) {
                         nodeBinding.values[x][y].vertexOffsets = filterResult[0];
                     }
-                } else {
+                } else if (translateChildren) {
                     auto vertices = [node.localTransform.translation.xy];
                     mat4 matrix = node.parent? node.parent.transform.matrix: mat4.identity;
 

--- a/source/inochi2d/core/nodes/package.d
+++ b/source/inochi2d/core/nodes/package.d
@@ -972,8 +972,10 @@ public:
     void reparent(Node parent, ulong pOffset) {
         setRelativeTo(parent);
         insertInto(parent, pOffset);
-        if (parent !is null) {
-            parent.setupChild(this);
+        auto p = parent;
+        while (p !is null) {
+            p.setupChild(this);
+            p = p.parent;
         }
     }
 

--- a/source/inochi2d/core/nodes/package.d
+++ b/source/inochi2d/core/nodes/package.d
@@ -19,6 +19,8 @@ public import inochi2d.core.nodes.drawable;
 public import inochi2d.core.nodes.composite;
 public import inochi2d.core.nodes.meshgroup;
 public import inochi2d.core.nodes.drivers; 
+import std.typecons: tuple, Tuple;
+
 //public import inochi2d.core.nodes.shapes; // This isn't mainline yet!
 
 import std.exception;
@@ -96,6 +98,8 @@ private:
     string nodePath_;
 
 protected:
+    bool preProcessed  = false;
+    bool postProcessed = false;
 
     /**
         The offset to the transform to apply
@@ -155,6 +159,53 @@ protected:
         serializeSelfImpl(serializer, true);
     }
 
+    @Ignore
+    mat4* oneTimeTransform = null;
+
+    @Ignore
+    class MatrixHolder {
+    public:
+        this(mat4 matrix) {
+            this.matrix = matrix;
+        }
+        mat4 matrix;
+    }
+    MatrixHolder overrideTransformMatrix = null;
+
+    Tuple!(vec2[], mat4*) delegate(vec2[], vec2[], mat4*) preProcessFilter  = null;
+    Tuple!(vec2[], mat4*) delegate(vec2[], vec2[], mat4*) postProcessFilter = null;
+
+    import std.stdio;
+    void preProcess() {
+        if (preProcessed)
+            return;
+        preProcessed = true;
+        if (preProcessFilter !is null) {
+            overrideTransformMatrix = null;
+            mat4 matrix = this.parent? this.parent.transform.matrix: mat4.identity;
+            auto filterResult = preProcessFilter([localTransform.translation.xy], [offsetTransform.translation.xy], &matrix);
+            if (filterResult[0] !is null && filterResult[0].length > 0) {
+                offsetTransform.translation = vec3(filterResult[0][0], offsetTransform.translation.z);
+                transformChanged();
+            } 
+        }
+    }
+
+    void postProcess() {
+        if (postProcessed)
+            return;
+        postProcessed = true;
+        if (postProcessFilter !is null) {
+            overrideTransformMatrix = null;
+            mat4 matrix = this.parent? this.parent.transform.matrix: mat4.identity;
+            auto filterResult = postProcessFilter([localTransform.translation.xy], [offsetTransform.translation.xy], &matrix);
+            if (filterResult[0] !is null && filterResult[0].length > 0) {
+                offsetTransform.translation = vec3(filterResult[0][0], offsetTransform.translation.z);
+                transformChanged();
+                overrideTransformMatrix = new MatrixHolder(transform.matrix);
+            } 
+        }
+    }
 
 package(inochi2d):
 
@@ -689,6 +740,9 @@ public:
     }
 
     void beginUpdate() {
+        preProcessed  = false;
+        postProcessed = false;
+
         offsetSort = 0;
         offsetTransform.clear();
 
@@ -702,11 +756,14 @@ public:
         Updates the node
     */
     void update() {
+        preProcess();
+
         if (!enabled) return;
 
         foreach(child; children) {
             child.update();
         }
+        postProcess();
     }
 
     /**
@@ -895,6 +952,20 @@ public:
         inDbgLineWidth(1);
     }
 
+
+    void setOneTimeTransform(mat4* transform) {
+        oneTimeTransform = transform;
+
+        foreach (c; children) {
+            if (Drawable d = cast(Drawable)c)
+                d.setOneTimeTransform(transform);
+        }
+    }
+
+    mat4* getOneTimeTransform() {
+        return oneTimeTransform;
+    }
+
     /** 
      * set new Parent
      */
@@ -907,6 +978,14 @@ public:
     }
 
     void setupChild(Node child) {
+    }
+
+    mat4 getDynamicMatrix() {
+        if (overrideTransformMatrix !is null) {
+            return overrideTransformMatrix.matrix;
+        } else {
+            return transform.matrix;
+        }
     }
 }
 


### PR DESCRIPTION
Added new mode for MeshGroup object.
MeshGroup object has "translateChildren" parameter.
If this parameter is set, MeshGroup moves origin of Node and MeshGroup child nodes in addition to transformation for Drawable. This behavior is basically same as spline editor operation for Node except for this operation only affect translation.
<div><video controls src="https://user-images.githubusercontent.com/449741/231191641-f2a7c901-5e85-47c1-8e31-6beb2707e27b.mp4" muted="false"></video></div>

This makes deformation of some parts like face easy.

Currently MeshGroup under MeshGroup parent has some problem, but seems fine for other Node object.