### PR TITLE
Reset blend equation in renderScene()

### DIFF
--- a/source/inochi2d/core/package.d
+++ b/source/inochi2d/core/package.d
@@ -103,6 +103,7 @@ private {
         glDisable(GL_CULL_FACE);
         glDisable(GL_DEPTH_TEST);
         glEnable(GL_BLEND);
+        glBlendEquation(GL_FUNC_ADD);
         glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 
         shaderToUse.shader.use();


### PR DESCRIPTION
Mesa was throwing a `GL_INVALID_OPERATION` from the `glDrawArrays` call further down because an advanced blending mode was still enabled, while the scene fragment shader has no `blend_support`.

See [this test] in `_mesa_update_valid_to_render_state` for the code which detected this condition.

[this test]: https://gitlab.freedesktop.org/mesa/mesa/-/blob/47e7b49c61ed72141b20ee9061a320bd259b3e0d/src/mesa/main/draw_validate.c#L132

The blending mode was likely last set from `inSetBlendMode` in [source/inochi2d/core/nodes/common.d][inSetBlendMode].

[inSetBlendMode]: https://github.com/Inochi2D/inochi2d/blob/d32e41fa7ab900e2fe7fdea0e25f242fcea94de7/source/inochi2d/core/nodes/common.d#L197-L247

This patch resets the blend equation before drawing the scene.

Fixes Inochi2D/inochi-session#36.