### PR TITLE
Fix for some problems on reparent with null parent.

### DIFF
--- a/source/inochi2d/core/nodes/package.d
+++ b/source/inochi2d/core/nodes/package.d
@@ -983,7 +983,8 @@ public:
 
         unsetGroup(this);
 
-        setRelativeTo(parent);
+        if (parent !is null)
+            setRelativeTo(parent);
         insertInto(parent, pOffset);
         auto c = this;
         for (auto p = parent; p !is null; p = p.parent, c = c.parent) {

--- a/source/inochi2d/core/nodes/package.d
+++ b/source/inochi2d/core/nodes/package.d
@@ -845,8 +845,8 @@ public:
         this.uuid_ = uuid;
     }
 
-    rect getCombinedBoundsRect() {
-        vec4 combinedBounds = getCombinedBounds();
+    rect getCombinedBoundsRect(bool reupdate = false, bool countPuppet=false)() {
+        vec4 combinedBounds = getCombinedBounds!(reupdate, countPuppet)();
         return rect(
             combinedBounds.x, 
             combinedBounds.y, 


### PR DESCRIPTION
Current implementation crashed when null parent is passed to Node.reparent method.
This patch fixes to avoid crash on that case, and node is simply removed from the tree.
Also getCombinedBoundsRect is enhanced in order to be able to specify the template parameter same as getCombinedBounds.