### PR TITLE
Experimental: Enable nesting for MeshGroup.

### DIFF
--- a/source/inochi2d/core/nodes/drawable.d
+++ b/source/inochi2d/core/nodes/drawable.d
@@ -79,6 +79,7 @@ private:
         this.updateDeform();
     }
 
+protected:
     void updateDeform() {
         // Important check since the user can change this every frame
         enforce(
@@ -95,7 +96,6 @@ private:
         this.updateBounds();
     }
 
-protected:
     /**
         OpenGL Index Buffer Object
     */

--- a/source/inochi2d/core/nodes/meshgroup/package.d
+++ b/source/inochi2d/core/nodes/meshgroup/package.d
@@ -284,7 +284,8 @@ public:
         void setGroup(Node node) {
             auto drawable = cast(Drawable)node;
             auto group    = cast(MeshGroup)node;
-            bool isDrawable = drawable !is null && group is null;
+            bool isDrawable = drawable !is null;
+            bool mustPropagate = isDrawable && group is null;
             if (translateChildren || isDrawable) {
                 if (isDrawable && dynamic) {
                     node.preProcessFilter  = null;
@@ -298,7 +299,7 @@ public:
                 node.postProcessFilter = null;
             }
             // traverse children if node is Drawable and is not MeshGroup instance.
-            if (isDrawable) {
+            if (mustPropagate) {
                 foreach (child; node.children) {
                     setGroup(child);
                 }
@@ -325,8 +326,9 @@ public:
             void transferChildren(Node node, int x, int y) {
                 auto drawable = cast(Drawable)node;
                 auto group = cast(MeshGroup)node;
-                bool isDrawable = drawable !is null && group is null;
-                if (drawable) {
+                bool isDrawable = drawable !is null;
+                bool mustPropagate = isDrawable && group is null;
+                if (isDrawable) {
                     auto vertices = drawable.vertices;
                     mat4 matrix = drawable.transform.matrix;
 
@@ -353,7 +355,7 @@ public:
                     }
 
                 }
-                if (isDrawable) {
+                if (mustPropagate) {
                     foreach (child; node.children) {
                         transferChildren(child, x, y);
                     }

--- a/source/inochi2d/core/nodes/meshgroup/package.d
+++ b/source/inochi2d/core/nodes/meshgroup/package.d
@@ -54,12 +54,12 @@ protected:
 
     override
     void preProcess() {
-        Node.preProcess();
+        super.preProcess();
     }
 
     override
     void postProcess() {
-        Node.postProcess();
+        super.preProcess();
     }
 
 public:
@@ -112,6 +112,9 @@ public:
     */
     override
     void update() {
+        preProcess();
+        deformStack.update();
+        
         if (data.indices.length > 0) {
             if (!precalculated) {
                 precalculate();
@@ -132,8 +135,9 @@ public:
             inverseMatrix = globalTransform.matrix.inverse;
         }
 
-       super.update(); 
-    }
+        Node.update();
+        this.updateDeform();
+   }
 
     override
     void draw() {
@@ -322,7 +326,7 @@ public:
                 auto drawable = cast(Drawable)node;
                 auto group = cast(MeshGroup)node;
                 bool isDrawable = drawable !is null && group is null;
-                if (isDrawable) {
+                if (drawable) {
                     auto vertices = drawable.vertices;
                     mat4 matrix = drawable.transform.matrix;
 


### PR DESCRIPTION
This small patch enables nesting of MeshGroup for static mode.
It seems partially working for dynamic mode, too.

It may break more compatibility b/w exported INP file and INX file, if MeshGroup has T/R/S transformation.
As far as model has no direct nesting in existing model (means it has intermediate Node object), I believe nothing is different.
I'd like to test it if it works correctly widely.
