### PR TITLE
Fix tint not applying when bound to a parameter

### DIFF
--- a/source/inochi2d/core/nodes/composite/package.d
+++ b/source/inochi2d/core/nodes/composite/package.d
@@ -398,13 +398,13 @@ public:
                 offsetOpacity *= value;
                 return true;
             case "tint.r":
-                offsetTint.x += value;
+                offsetTint.x *= value;
                 return true;
             case "tint.g":
-                offsetTint.y += value;
+                offsetTint.y *= value;
                 return true;
             case "tint.b":
-                offsetTint.z += value;
+                offsetTint.z *= value;
                 return true;
             case "screenTint.r":
                 offsetScreenTint.x += value;

--- a/source/inochi2d/core/nodes/part/package.d
+++ b/source/inochi2d/core/nodes/part/package.d
@@ -731,13 +731,13 @@ public:
                 offsetTint.z *= value;
                 return true;
             case "screenTint.r":
-                offsetScreenTint.x *= value;
+                offsetScreenTint.x += value;
                 return true;
             case "screenTint.g":
-                offsetScreenTint.y *= value;
+                offsetScreenTint.y += value;
                 return true;
             case "screenTint.b":
-                offsetScreenTint.z *= value;
+                offsetScreenTint.z += value;
                 return true;
             case "emissionStrength":
                 offsetEmissionStrength += value;


### PR DESCRIPTION
Fixes tint (multiply) not working with composite nodes when bound to a parameter, and fixes tint (screen) not working with part nodes when bound to a parameter.

The wrong operations were used for calculating the tint. Composites used addition for both multiply and screen, while parts used multiplication for both.

Fixes https://github.com/Inochi2D/inochi-creator/issues/315