### PR TITLE
MeshGroup: allow nest for dynamic-dynamic meshgroup and dynamic-static meshgroup.

### DIFF
--- a/source/inochi2d/core/nodes/drawable.d
+++ b/source/inochi2d/core/nodes/drawable.d
@@ -297,7 +297,12 @@ public:
         preProcess();
         deformStack.update();
         super.update();
+    }
+
+    override
+    void endUpdate() {
         this.updateDeform();
+        super.endUpdate();
     }
 
     /**

--- a/source/inochi2d/core/nodes/meshgroup/package.d
+++ b/source/inochi2d/core/nodes/meshgroup/package.d
@@ -295,7 +295,7 @@ public:
             auto composite = cast(Composite)node;
             bool isDrawable = drawable !is null;
             bool isComposite = composite !is null && composite.propagateMeshGroup;
-            bool mustPropagate = (isDrawable && group is null) || isComposite;
+            bool mustPropagate = (isDrawable && group is null) || (group !is null && group.data.indices.length == 0) || isComposite;
             if (translateChildren || isDrawable) {
                 if (isDrawable && dynamic) {
                     node.preProcessFilter  = null;
@@ -332,18 +332,6 @@ public:
         forwardMatrix = transform.matrix;
         inverseMatrix = globalTransform.matrix.inverse;
 
-        bool isDescendantOfDynamicMG(MeshGroup group) {
-            auto parent = group.parent;
-            while (parent) {
-                auto pg = cast(MeshGroup)parent;
-                if (pg !is null && pg.dynamic)
-                    return true;
-                parent = parent.parent;
-            }
-            return false;
-        }
-        if (isDescendantOfDynamicMG(this))
-            return;
         foreach (param; params) {
             void transferChildren(Node node, int x, int y) {
                 auto drawable = cast(Drawable)node;
@@ -351,7 +339,7 @@ public:
                 auto composite = cast(Composite)node;
                 bool isDrawable = drawable !is null;
                 bool isComposite = composite !is null && composite.propagateMeshGroup;
-                bool mustPropagate = (isDrawable && group is null) || isComposite;
+                bool mustPropagate = (isDrawable && group is null) || (group !is null && group.data.indices.length == 0) || isComposite;
                 if (isDrawable) {
                     auto vertices = drawable.vertices;
                     mat4 matrix = drawable.transform.matrix;

--- a/source/inochi2d/core/nodes/package.d
+++ b/source/inochi2d/core/nodes/package.d
@@ -763,7 +763,16 @@ public:
         foreach(child; children) {
             child.update();
         }
+    }
+
+    /**
+        Complete update
+    */
+    void endUpdate() {
         postProcess();
+        foreach(child; children) {
+            child.endUpdate();
+        }
     }
 
     /**

--- a/source/inochi2d/core/puppet.d
+++ b/source/inochi2d/core/puppet.d
@@ -450,6 +450,9 @@ public:
 
         // Update nodes
         root.update();
+
+        // Complete updates
+        root.endUpdate();
     }
 
     /**


### PR DESCRIPTION
This is experimental, and break some compatibility for postProcessing. (believe it won't affect in practice.)

Application order of postProcess() is changed:
Currently, it is called children-to-parent order.
Now, it is changed to parent-to-children order.

In this way, Dynamic meshgroup can be nested.
If we implemented welding as a postProcess, it will be simpler if we can ensure that postProcess() is called after all of the node completed update() call.

Internally,following changes are made:
- Added Node.endUpdate.
- updateDeform is moved from Drawable.update to Drawable.endUpdate
- Puppet.update calls root.endUpdate
- filterChildren not return forwardMatrix anymore.