### PR TITLE
Fix for Inochi-Creator Issue 342 - Transparent img export post-process. 

### DIFF
--- a/source/inochi2d/core/package.d
+++ b/source/inochi2d/core/package.d
@@ -322,6 +322,7 @@ void inPostProcessScene() {
     
     bool targetBuffer;
 
+    // These are passed to glSetClearColor for transparent export
     float r, g, b, a;
     inGetClearColor(r, g, b, a);
 
@@ -352,6 +353,7 @@ void inPostProcessScene() {
     // We want to be able to post process all the attachments
     glBindFramebuffer(GL_FRAMEBUFFER, cfBuffer);
     glDrawBuffers(3, [GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1, GL_COLOR_ATTACHMENT2].ptr);
+    glClearColor(r, g, b, a);
     glClear(GL_COLOR_BUFFER_BIT);
 
     glBindFramebuffer(GL_FRAMEBUFFER, fBuffer);


### PR DESCRIPTION
Setting the Clear-Color prior to clearing the buffer fixes the background not being transparent when post-processing is enabled. 

Fixes this issue: https://github.com/Inochi2D/inochi-creator/issues/342

I believe this bug is just a mistake - the clear-color was obtained and then never-used. 