### PR TITLE
Welding implementation.

### DIFF
--- a/source/inochi2d/core/nodes/drivers/simplephysics.d
+++ b/source/inochi2d/core/nodes/drivers/simplephysics.d
@@ -642,6 +642,30 @@ public:
 
     /// Gets the final length damping
     vec2 getOutputScale() { return outputScale * offsetOutputScale; }
+
+    override
+    void copyFrom(Node src, bool inPlace = false, bool deepCopy = true) {
+        super.copyFrom(src, inPlace, deepCopy);
+
+        if (auto sphysics = cast(SimplePhysics)src) {
+            modelType_ = sphysics.modelType_;
+            mapMode = sphysics.mapMode;
+            localOnly = sphysics.localOnly;
+            gravity = sphysics.gravity;
+            length = sphysics.length;
+            frequency = sphysics.frequency;
+            angleDamping = sphysics.angleDamping;
+            lengthDamping = sphysics.lengthDamping;
+            outputScale = sphysics.outputScale;
+            prevAnchorSet = false;
+            anchor = vec2(0, 0);
+            system = sphysics.system;
+
+            paramRef = sphysics.paramRef;
+            param_ = sphysics.param_;
+        }
+    }
+
 }
 
 mixin InNode!SimplePhysics;

--- a/source/inochi2d/core/nodes/package.d
+++ b/source/inochi2d/core/nodes/package.d
@@ -108,7 +108,7 @@ protected:
     /**
         Whether the node is enabled
     */
-    bool enabled = true;
+    bool enabled_ = true;
 
 
     /**
@@ -138,7 +138,7 @@ protected:
         serializer.putValue(typeId);
         
         serializer.putKey("enabled");
-        serializer.putValue(enabled);
+        serializer.putValue(enabled_);
         
         serializer.putKey("zsort");
         serializer.putValue(zsort_);
@@ -811,7 +811,7 @@ public:
             this.name = this.name.toStringz.fromStringz;
         }
 
-        if (auto exc = data["enabled"].deserializeValue(this.enabled)) return exc;
+        if (auto exc = data["enabled"].deserializeValue(this.enabled_)) return exc;
 
         if (auto exc = data["zsort"].deserializeValue(this.zsort_)) return exc;
         
@@ -1011,11 +1011,13 @@ public:
     void clearCache() { }
     void normalizeUV(MeshData* data) { }
 
-    bool getEnabled() { return enabled; }
-    void setEnabled(bool value) { 
-        bool changed = enabled != value;
-        enabled = value;
+    bool enabled() { return enabled_; }
+    void enabled(bool value) { 
+        bool changed = enabled_ != value;
+        enabled_ = value;
     }
+    final bool getEnabled() { return enabled_; }
+    final void setEnabled(bool value) { enabled(value); }
 
     void centralize() {
         foreach (child; children) {

--- a/source/inochi2d/core/nodes/part/package.d
+++ b/source/inochi2d/core/nodes/part/package.d
@@ -305,6 +305,7 @@ private:
         }
     }
 
+protected:
     /*
         RENDERING
     */
@@ -376,8 +377,6 @@ private:
         glDrawBuffers(3, [GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1, GL_COLOR_ATTACHMENT2].ptr);
         glBlendEquation(GL_FUNC_ADD);
     }
-
-protected:
 
     override
     string typeId() { return "Part"; }
@@ -872,6 +871,39 @@ public:
         }
     }
 
+    override
+    void normalizeUV(MeshData* data) {
+        // Texture 0 is always albedo texture
+        auto tex = textures[0];
+        foreach (i; 0..data.uvs.length) {
+            data.uvs[i].x /= cast(float)tex.width;
+            data.uvs[i].y /= cast(float)tex.height;
+            data.uvs[i] += vec2(0.5, 0.5);
+        }
+    }
+
+    override
+    void copyFrom(Node src, bool inPlace = false, bool deepCopy = true) {
+        super.copyFrom(src, inPlace, deepCopy);
+
+        if (auto part = cast(Part)src) {
+            offsetMaskThreshold = 0;
+            offsetOpacity = 1;
+            offsetEmissionStrength = 1;
+            offsetTint = vec3(0);
+            offsetScreenTint = vec3(0);
+
+            textures = part.textures.dup;
+            textureIds = part.textureIds.dup;
+            masks = part.masks.dup;
+            blendingMode = part.blendingMode;
+            maskAlphaThreshold = part.maskAlphaThreshold;
+            opacity = part.opacity;
+            emissionStrength = part.emissionStrength;
+            tint = part.tint;
+            screenTint = part.screenTint;
+        }
+    }
 }
 
 /**
@@ -935,6 +967,8 @@ void inDrawTextureAtPart(Texture texture, Part part) {
     Draws a texture at the transform of the specified part
 */
 void inDrawTextureAtPosition(Texture texture, vec2 position, float opacity = 1, vec3 color = vec3(1, 1, 1), vec3 screenColor = vec3(0, 0, 0)) {
+    if (texture is null) return;
+    
     const float texWidthP = texture.width()/2;
     const float texHeightP = texture.height()/2;
 

--- a/source/inochi2d/core/nodes/utils.d
+++ b/source/inochi2d/core/nodes/utils.d
@@ -1,0 +1,11 @@
+module inochi2d.core.nodes.utils;
+import std.algorithm.mutation: remove;
+import std.algorithm.searching;
+
+T[] removeByValue(T)(T[] array, T value) {
+    auto index = array.countUntil(value);
+    if (index != -1) {
+        return array.remove(index);
+    }
+    return array;
+}

--- a/source/inochi2d/core/param/binding.d
+++ b/source/inochi2d/core/param/binding.d
@@ -136,6 +136,8 @@ abstract class ParameterBinding {
     */
     BindTarget getTarget();
 
+    abstract void setTarget(Node node, string paramName);
+
     /**
         Gets name of binding
     */
@@ -216,6 +218,12 @@ public:
     override
     BindTarget getTarget() {
         return target;
+    }
+
+    override
+    void setTarget(Node node, string paramName) {
+        target.node = node;
+        target.paramName = paramName;
     }
 
     /**


### PR DESCRIPTION
Added welding functionality to Inochi2D.
Welding is implemented using enhancement to preProcess / postProcess.
Following methods are added.

Some basic method definitions are moved from creator to inochi2d.(such as centralize, copyFrom, dup, etc.)

# Node
 ## Added interfaces for common manipulation for Node subclasses:

  +    endUpdate()
    Post processing are called from parent to client order.

  +    void releaseChild(Node child)
    Called when children are released from ancestors.

  +    void setupSelf()
    Called after setupChild is called.

  +    void releaseSelf()
    Called before releaseChild is called.

  +    void clearCache()
    Called to clear cache. generalization of MeshGroup method.

  +    void normalizeUV(MeshData* data)
    Called to define UV coordinates.

  +    bool getEnabled()
  +    void setEnabled(bool value)
    Setter / getter for Node.enabled.

  +    void centralize()
    Implementation of "Recalculate origin." Subclasses will override to customize behaviour.

  +    void copyFrom(Node src, bool inPlace = false, bool deepCopy = true)
    Called to create copy from src object. This can be used to copy src, and convert type from src.

  +    Node dup()
    Called to create deep copy of self.

  +    void build(bool force = false)
    Called to prepare resources before `draw` is called.

 ## Updated following methods:
  +    preProcess / postProcess
    Multiple filters can be added. Welding and MeshGroup shares same callback framework, now it can handle multiple 
filter>

# Drawable
 ## Added following methods:

  +    weldingProcessor
    Callback filters for welding implementation.

  +    addWeldedTarget(Drawable target, ptrdiff_t[] weldedVertexIndices, float weldingWeight)
  +    removeWeldedTarget(Drawable target)
    Called to manipulate welded links between Parts.

  +    isWeldedBy(Drawable target)
    Returns whether target is welded by this object.

# MeshGroup
 ## Changed filter implementation for multiple preProcess/postProcess filters.
 ## Implemented releaseChild, centralize, copyFrom, build etc.

# Part
 ## Implemented copyFrom, normalizeUV etc.
# SimplePhysics
 ## Implemented copyFrom.